### PR TITLE
Update method was accessing the board array with swapped indices. It …

### DIFF
--- a/chess/Form1.cs
+++ b/chess/Form1.cs
@@ -13,62 +13,70 @@ namespace chess
 {
     public partial class Form1 : Form
     {
-        Piece[,] board;
-        Graphics graphics;
-        Board b=new Board();
-        Image piecesimg;
-        int hieght;
-        int width;
+        private Piece[,] board;
+        private Graphics graphics;
+        private Board b = new Board();
+        private Image piecesimg;
+        private int height;
+        private int width;
+
         public Form1()
         {
             InitializeComponent();
+
             pictureBox2.Parent = pictureBox1;
-            pictureBox1.SizeMode=PictureBoxSizeMode.StretchImage;
+            pictureBox1.SizeMode = PictureBoxSizeMode.StretchImage;
             pictureBox1.Image = Board.boardimg;
-            hieght = pictureBox2.Size.Height;
+            height = pictureBox2.Size.Height;
             width = pictureBox2.Size.Width;
             DoubleBuffered = true;
-         GameBegin();    
-            
+
+            GameBegin();
         }
+
         private void GameBegin()
         {
-            
-            if(board==null)board=new Piece[8,8];
-           b.SetBoard();
-           
-           if (piecesimg == null) piecesimg = new Bitmap(width,hieght);
-           graphics = Graphics.FromImage(piecesimg);
-           update();
+            if (board == null)
+                board = new Piece[8, 8];
+
+            b.SetBoard();
+
+            if (piecesimg == null)
+                piecesimg = new Bitmap(width, height);
+
+            graphics = Graphics.FromImage(piecesimg);
+            update();
         }
+
         private void update()
         {
             graphics.Clear(Color.Transparent);
-             board = b.GetBoard();
-            for(int i=0;i<8;i++){
-                 for(int j=0;j<8;j++){
-                     if (board[i, j] != null)
-                     {
-                         graphics.DrawImage(board[j, i].img, new Rectangle( i* (width/8), j *(hieght/8), width/8, hieght/8));
-                   }
-                 }
+            board = b.GetBoard();
+
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    if (board[i, j] != null)
+                    {
+                        graphics.DrawImage(board[i, j].img, new Rectangle(i * (width / 8), j * (height / 8), width / 8, height / 8));
+                    }
+                }
             }
+
             pictureBox2.Image = piecesimg;
         }
 
-
         private void pictureBox1_Click(object sender, EventArgs e)
         {
-            
         }
 
         private void pictureBox2_Click(object sender, EventArgs e)
-        { 
+        {
         }
 
         private void Form1_Load(object sender, EventArgs e)
         {
-
         }
     }
 }


### PR DESCRIPTION
Resolves #1 
Crash fixed: Update method was accessing the board array with swapped indices. It was checking if [i, j] was not null and then accessing [j, i].

Misc:
- Corrected the spelling of "height".
- Made the implicitly private fields explicitly private.
- Made spacing, line breaks, etc. more consistent.
